### PR TITLE
fix: Java 배포판(Temurin) 명시

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 21
+          distribution: 'temurin'
 
       - name: Build with Maven
         run: mvn clean package


### PR DESCRIPTION
**GitHub Actions의 setup-java 액션에서 distribution 옵션이 필요한 이유는 어떤 Java 배포판(distribution)을 설치할지 명시적으로 지정해야 하기 때문입니다.**

distribution 옵션의 필요성
Java 배포판이 다양함:

Java는 여러 기관에서 배포판(Distribution)을 제공합니다. 예를 들어:
Temurin: Eclipse Adoptium의 OpenJDK 배포판 (가장 널리 사용되고 안정적임).
Zulu: Azul Systems의 OpenJDK 배포판.
AdoptOpenJDK: 이전에 많이 사용되었지만, 현재는 Adoptium으로 통합됨.
GitHub Actions는 여러 배포판을 지원하기 때문에, 정확히 어떤 배포판을 사용할지 알려줘야 합니다.
디폴트 배포판이 없어짐:

예전에는 setup-java 액션에서 배포판을 지정하지 않으면 기본값이 설정되었지만, 최신 버전(3.x)에서는 distribution을 명시적으로 지정해야만 동작합니다.
