### PR TITLE
feat: github Actions 테스트 환경 설정을 위한 MySQL 서비스 설정 추가

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -9,6 +9,20 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    services:
+      mysql:
+        image: mysql:8.0
+        ports:
+          - 3306:3306
+        env:
+          MYSQL_ROOT_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
+          MYSQL_DATABASE: payphone_db
+        options: >-
+          --health-cmd="mysqladmin ping -h localhost"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -18,6 +32,14 @@ jobs:
         with:
           java-version: 21
           distribution: 'temurin'
+
+      - name: Run tests with Maven
+        env:
+          SPRING_PROFILES_ACTIVE: test
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DATABASE_USERNAME: ${{ secrets.DATABASE_USERNAME }}
+          DATABASE_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
+        run: mvn clean test
 
       - name: Build with Maven
         run: mvn clean package


### PR DESCRIPTION
## 📋 수정 사항 요약
- GitHub Actions에서 테스트 실행 시 필요한 **MySQL 서비스**를 설정.
- MySQL 컨테이너를 추가하여 백엔드 테스트 환경에서 데이터베이스 의존성을 해결.
- 초기 스키마 설정을 통해 테스트 데이터베이스 준비.

---

## ✅ 체크리스트
- [x] GitHub Actions 워크플로우에 MySQL 서비스 추가
- [x] 테스트 단계에서 MySQL 데이터베이스에 연결 테스트
- [x] MySQL 초기 스키마 및 데이터베이스 생성 확인
- [x] 로컬 환경과 동일한 MySQL 설정 적용

---

## 📂 변경된 파일
- `.github/workflows/backend-ci.yml`

---

## 📊 테스트 결과
- GitHub Actions에서 MySQL 컨테이너를 실행한 후 정상적으로 테스트 성공.
- 초기 스키마 적용 및 연결 테스트 확인 완료.

---

## 🔍 참고 사항
- MySQL은 GitHub Actions에서 Docker 컨테이너로 실행됩니다.
- `.github/workflows/backend-ci.yml`에서 `services.mysql` 블록을 추가.
- 추후 테스트 데이터를 초기화하거나, 더 복잡한 설정이 필요할 경우 `init.sql`을 추가할 예정.


---

## 🤔 고민거리

- MySQL 설정? H2 임시 데이터?
- 1) 임시 데이터베이스
의미: 테스트 중에만 사용되는 메모리 기반 데이터베이스입니다.
예시: H2 데이터베이스(메모리 내에서 동작).
장점:
설정이 간단하고, 실제 데이터베이스를 준비하지 않아도 됨.
테스트 데이터가 자동으로 초기화되어 데이터 충돌이 발생하지 않음.
단점:
MySQL 같은 실제 환경과는 동작 방식이 다를 수 있음.
- 2) 로컬 데이터베이스를 대신할 MySQL 서비스
의미: GitHub Actions 환경에서 Docker로 MySQL 서버를 실행해 테스트에서 실제 MySQL과 동일한 환경을 제공합니다.
장점:
실제 MySQL과 동일한 동작을 보장.
실제 환경과 유사하게 테스트 가능.
단점:
설정이 비교적 복잡할 수 있음.
테스트 속도가 느릴 수 있음.

- 결론:
    - MySQL 서비스 방식 선택
위 설정으로 GitHub Actions에서 MySQL 서비스를 실행하여, 실제 데이터베이스와 동일한 환경에서 테스트를 진행할 수 있습니다.
나중에 더 고도화된 테스트 환경이 필요하면, H2 같은 메모리 데이터베이스를 추가로 고려할 수 있습니다.
