### PR TITLE
fix: AWS CodeDeploy 배포를 위해 GitHub Actions 워크플로를 수정해야 합니다. AWS CLI 명령을…

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -9,20 +9,6 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
 
-    services:
-      mysql:
-        image: mysql:8.0
-        ports:
-          - 3306:3306
-        env:
-          MYSQL_ROOT_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
-          MYSQL_DATABASE: payphone_db
-        options: >-
-          --health-cmd="mysqladmin ping -h localhost"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=3
-
     steps:
       # 1. Checkout Repository
       - name: Checkout code
@@ -37,11 +23,6 @@ jobs:
 
       # 3. Run Tests
       - name: Run tests with Maven
-        env:
-          SPRING_PROFILES_ACTIVE: test
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          DATABASE_USERNAME: ${{ secrets.DATABASE_USERNAME }}
-          DATABASE_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
         run: mvn clean test
 
       # 4. Build Jar
@@ -50,26 +31,22 @@ jobs:
 
       # 5. Upload to S3
       - name: Upload Jar to S3
-        uses: jakejarvis/s3-sync-action@v0.5.1
-        with:
-          args: --acl public-read
+        run: |
+          aws s3 cp ./target/payphone-backend-0.0.1-SNAPSHOT.jar s3://${{ secrets.DEPLOY_S3_BUCKET }}/
         env:
-          AWS_S3_BUCKET: ${{ secrets.DEPLOY_S3_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: ${{ secrets.AWS_REGION }}
-          SOURCE_DIR: ./target/payphone-backend-0.0.1-SNAPSHOT.jar
-          DEST_DIR: /
 
-      # 6. Trigger CodeDeploy
-      - name: Trigger CodeDeploy
-        uses: aws-actions/aws-code-deploy@v1
-        with:
-          application-name: ${{ secrets.DEPLOY_APPLICATION_NAME }}
-          deployment-group: ${{ secrets.DEPLOY_GROUP_NAME }}
-          deployment-config: CodeDeployDefault.OneAtATime
-          bundle-type: zip
-          region: ${{ secrets.AWS_REGION }}
+      # 6. Trigger CodeDeploy Deployment
+      - name: Deploy to EC2 with CodeDeploy
+        run: |
+          aws deploy create-deployment \
+            --application-name ${{ secrets.DEPLOY_APPLICATION_NAME }} \
+            --deployment-group-name ${{ secrets.DEPLOY_GROUP_NAME }} \
+            --deployment-config-name CodeDeployDefault.OneAtATime \
+            --s3-location bucket=${{ secrets.DEPLOY_S3_BUCKET }},key=payphone-backend-0.0.1-SNAPSHOT.jar,bundleType=zip
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}


### PR DESCRIPTION
이전 backend-ci.yml의 문제 원인
1. GitHub Actions의 잘못된 액션 이름
aws-actions/aws-code-deploy라는 액션은 존재하지 않습니다. 대신, AWS와 관련된 배포 작업을 수행하려면 다른 방법을 사용해야 합니다.
2. 올바른 액션을 사용하지 않음
AWS 배포를 위해 올바른 GitHub Actions 또는 스크립트 기반 접근 방식이 필요합니다.
